### PR TITLE
Fix misuses read and write pointers

### DIFF
--- a/avr/bootloaders/athena/src/Makefile
+++ b/avr/bootloaders/athena/src/Makefile
@@ -63,7 +63,7 @@ ifeq ($(ENV), arduino)
 # For Arduino, we assume that we're connected to the optiboot directory
 # included with the arduino distribution, which means that the full set
 # of avr-tools are "right up there" in standard places.
-TOOLROOT = ../../../tools
+TOOLROOT ?= ../../../tools
 GCCROOT = $(TOOLROOT)/avr/bin/
 AVRDUDE_CONF = -C$(TOOLROOT)/avr/etc/avrdude.conf
 
@@ -80,10 +80,10 @@ else ifeq ($(ENV), arduinodev)
 # Arduino IDE source code environment.  Use the unpacked compilers created
 # by the build (you'll need to do "ant build" first.)
 ifeq ($(OS), macosx)
-TOOLROOT = ../../../../build/macosx/work/Arduino.app/Contents/Resources/Java/hardware/tools
+TOOLROOT ?= ../../../../build/macosx/work/Arduino.app/Contents/Resources/Java/hardware/tools
 endif
 ifeq ($(OS), windows)
-TOOLROOT = ../../../../build/windows/work/hardware/tools
+TOOLROOT ?= ../../../../build/windows/work/hardware/tools
 endif
 
 GCCROOT = $(TOOLROOT)/avr/bin/

--- a/avr/bootloaders/athena/src/debug/debug_main.h
+++ b/avr/bootloaders/athena/src/debug/debug_main.h
@@ -22,25 +22,33 @@ const unsigned char mDebugMain_PREFIX[] PROGMEM = "Main: ";
 const unsigned char mDebug_UpdateMode[] PROGMEM = "Update Mode Requested";
 const unsigned char mDebug_GoodImage[] PROGMEM = "Good image signature detected";
 const unsigned char mDebug_BadImage[] PROGMEM = "BAD image signature detected";
+
 #if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
 #if defined(ARDUINO_ETHERNET)
-const unsigned char mDebugMain_TITLE[] PROGMEM =
-	"Athena for Arduino Ethernet, Version " PP_STRINGIFY(BUILD_TAG);
+#define TITLE_BOARD_TYPE "Athena for Arduino Ethernet"
 #else
-const unsigned char mDebugMain_TITLE[] PROGMEM =
-	"Athena for Arduino Uno, Version " PP_STRINGIFY(BUILD_TAG);
+#define TITLE_BOARD_TYPE "Athena for Arduino Uno"
 #endif
 #elif defined(__AVR_ATmega2560__)
-const unsigned char mDebugMain_TITLE[] PROGMEM =
-	"Athena for Arduino Mega2560, Version " PP_STRINGIFY(BUILD_TAG);
+#define TITLE_BOARD_TYPE "Athena for Arduino Mega2560"
 #elif defined(__AVR_ATmega1284P__)
-const unsigned char mDebugMain_TITLE[] PROGMEM =
-	"Athena for Arduino Mega1284P, Version " PP_STRINGIFY(BUILD_TAG);
+#define TITLE_BOARD_TYPE "Athena for Arduino Mega1284P"
 #else
-const unsigned char mDebugMain_TITLE[] PROGMEM =
-	"Unknown MCU with athena, Version " PP_STRINGIFY(BUILD_TAG);
+#define TITLE_BOARD_TYPE "Unknown MCU with athena"
 #endif
+
+#if defined(__WIZ_W5100__)
+#define TITLE_WIZ_TYPE "W5100"
+#elif defined(__WIZ_W5200__)
+#define TITLE_WIZ_TYPE "W5200"
+#elif defined(__WIZ_W5500__)
+#define TITLE_WIZ_TYPE "W5500"
+#endif
+
+const unsigned char mDebugMain_TITLE[] PROGMEM =
+	TITLE_BOARD_TYPE " (" TITLE_WIZ_TYPE "), Version " PP_STRINGIFY(BUILD_TAG);
 const unsigned char mDebugMain_EXIT[] PROGMEM = "Start user app";
+
 #if(DEBUG_MAIN > 1)
 #undef DBG_MAIN_EX
 #define DBG_MAIN_EX(block) block

--- a/avr/bootloaders/athena/src/ethernet/tftp.c
+++ b/avr/bootloaders/athena/src/ethernet/tftp.c
@@ -121,13 +121,6 @@ static uint8_t processPacket(void)
 
 	DBG_TFTP_EX(tracePGMlnTftp(mDebugTftp_RPTR); tracenum(readPointer);)
 
-#if defined(__WIZ_W5500__)
-	// W5500 auto increments the readpointer by memory mapping a 16bit addr
-#else
-	if(readPointer == 0)
-		readPointer += S3_RX_START;
-#endif
-
 	for(count = TFTP_PACKET_MAX_SIZE; count--;)
 	{
 		DBG_TFTP_EX(if((count == TFTP_PACKET_MAX_SIZE - 1) || (count == 0)) {
@@ -137,12 +130,12 @@ static uint8_t processPacket(void)
 
 #if defined(__WIZ_W5500__)
 		*bufPtr++ = spiReadReg(readPointer++, S3_RXBUF_CB);
-		// W5500 auto increments the readpointer by memory mapping a 16bit addr
+		// W5500 have [automaticly] offset address mapping between the read pointer to the physical address
 		// Use uint16_t overflow from 0xFFFF to 0x10000 to follow W5500 internal pointer
 #else
-		*bufPtr++ = spiReadReg(readPointer++, 0);
-		if(readPointer == S3_RX_END)
-			readPointer = S3_RX_START;
+		*bufPtr++ = spiReadReg(S3_readPointer_to_phy_address(readPointer++), 0);
+		// W5100 & W5200 should read from the physical address
+		// address (relative to the base address) calculate by masking with the buffer size
 #endif
 	}
 

--- a/avr/bootloaders/athena/src/ethernet/tftp.c
+++ b/avr/bootloaders/athena/src/ethernet/tftp.c
@@ -515,7 +515,7 @@ uint8_t tftpPoll(void)
 	uint16_t packetSize;
 	uint16_t prev = 0;
 	uint8_t response = ACK;
-	
+
 	// Get the size of the recieved data
 	packetSize = spiReadWord(REG_S3_RX_RSR0, S3_R_CB);
 
@@ -523,7 +523,7 @@ uint8_t tftpPoll(void)
 	while(packetSize != prev)
 	{
 		_delay_ms(TFTP_PACKET_DELAY);
-		
+
 		prev = packetSize;
 		packetSize = spiReadWord(REG_S3_RX_RSR0, S3_R_CB);
 	}

--- a/avr/bootloaders/athena/src/ethernet/tftp.c
+++ b/avr/bootloaders/athena/src/ethernet/tftp.c
@@ -41,6 +41,13 @@ const unsigned char tftp_invalid_image_packet[] PROGMEM = "\0\5"
 														  "\0\0"
 														  "Invalid image file";
 
+uint8_t tftpFlashing;
+uint8_t tftpInitError;
+
+#ifndef TFTP_RANDOM_PORT
+uint16_t tftpTransferPort;
+#endif
+
 uint16_t lastPacket = 0, highPacket = 0;
 
 static void sockInit(uint16_t port)

--- a/avr/bootloaders/athena/src/ethernet/tftp.h
+++ b/avr/bootloaders/athena/src/ethernet/tftp.h
@@ -56,12 +56,8 @@
 /**
  * Tftp status flag, it is set to TRUE if flashing from
  * tftp is currently active */
-uint8_t tftpFlashing;
-uint8_t tftpInitError;
-
-#ifndef TFTP_RANDOM_PORT
-uint16_t tftpTransferPort;
-#endif
+extern uint8_t tftpFlashing;
+extern uint8_t tftpInitError;
 
 void tftpInit(void);
 uint8_t tftpPoll(void);

--- a/avr/bootloaders/athena/src/ethernet/tftp.h
+++ b/avr/bootloaders/athena/src/ethernet/tftp.h
@@ -36,11 +36,11 @@
 #define INVALID_IMAGE 5
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)
-#define MAX_ADDR 0x7000 /// For 328p/32u4 with 2Kword bootloader
+#define MAX_ADDR 0x7000 /// For 328p/32u4 with 2Kword (4K-Byte) bootloader
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1284P__)
-#define MAX_ADDR 0x1F000 /// For 1280 with 2Kword bootloader
+#define MAX_ADDR 0x1E000 /// For 1280 with 4Kword (8K-Byte) bootloader
 #elif defined(__AVR_ATmega2560__)
-#define MAX_ADDR 0x3F000 /// For 2560 with 2Kword bootloader
+#define MAX_ADDR 0x3E000 /// For 2560 with 4Kword (8K-Byte) bootloader
 #endif
 
 #define TFTP_DATA_SIZE 512

--- a/avr/bootloaders/athena/src/ethernet/tftp.h
+++ b/avr/bootloaders/athena/src/ethernet/tftp.h
@@ -51,7 +51,7 @@
 #define TFTP_PACKET_MAX_SIZE \
 	(UDP_HEADER_SIZE + TFTP_OPCODE_SIZE + TFTP_BLOCKNO_SIZE + TFTP_MAX_PAYLOAD)
 
-#define TFTP_PACKET_DELAY 400
+#define TFTP_PACKET_DELAY 5
 
 /**
  * Tftp status flag, it is set to TRUE if flashing from

--- a/avr/bootloaders/athena/src/ethernet/w5100.h
+++ b/avr/bootloaders/athena/src/ethernet/w5100.h
@@ -228,8 +228,10 @@
 #define S3_RX_START 0x7800
 #define S3_RX_END 0x8000
 
-#define S3_writePointer_to_phy_address(rptr) (S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
-#define S3_readPointer_to_phy_address(rptr)  (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+#define S3_map_writePointer_to_phy_address(rptr) \
+	(S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
+#define S3_map_readPointer_to_phy_address(rptr) \
+	(S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
 
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01

--- a/avr/bootloaders/athena/src/ethernet/w5100.h
+++ b/avr/bootloaders/athena/src/ethernet/w5100.h
@@ -228,7 +228,8 @@
 #define S3_RX_START 0x7800
 #define S3_RX_END 0x8000
 
-#define S3_readPointer_to_phy_address(rptr) (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+#define S3_writePointer_to_phy_address(rptr) (S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
+#define S3_readPointer_to_phy_address(rptr)  (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
 
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01

--- a/avr/bootloaders/athena/src/ethernet/w5100.h
+++ b/avr/bootloaders/athena/src/ethernet/w5100.h
@@ -228,6 +228,8 @@
 #define S3_RX_START 0x7800
 #define S3_RX_END 0x8000
 
+#define S3_readPointer_to_phy_address(rptr) (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01
 #define MR_UDP 0x02

--- a/avr/bootloaders/athena/src/ethernet/w5200.h
+++ b/avr/bootloaders/athena/src/ethernet/w5200.h
@@ -229,8 +229,10 @@
 #define S3_RX_START 0xD800
 #define S3_RX_END 0xE000
 
-#define S3_writePointer_to_phy_address(rptr) (S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
-#define S3_readPointer_to_phy_address(rptr)  (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+#define S3_map_writePointer_to_phy_address(rptr) \
+	(S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
+#define S3_map_readPointer_to_phy_address(rptr) \
+	(S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
 
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01

--- a/avr/bootloaders/athena/src/ethernet/w5200.h
+++ b/avr/bootloaders/athena/src/ethernet/w5200.h
@@ -229,7 +229,8 @@
 #define S3_RX_START 0xD800
 #define S3_RX_END 0xE000
 
-#define S3_readPointer_to_phy_address(rptr) (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+#define S3_writePointer_to_phy_address(rptr) (S3_TX_START + (rptr & (S3_TX_END - S3_TX_START - 1)))
+#define S3_readPointer_to_phy_address(rptr)  (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
 
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01

--- a/avr/bootloaders/athena/src/ethernet/w5200.h
+++ b/avr/bootloaders/athena/src/ethernet/w5200.h
@@ -229,6 +229,8 @@
 #define S3_RX_START 0xD800
 #define S3_RX_END 0xE000
 
+#define S3_readPointer_to_phy_address(rptr) (S3_RX_START + (rptr & (S3_RX_END - S3_RX_START - 1)))
+
 #define MR_CLOSED 0x00
 #define MR_TCP 0x01
 #define MR_UDP 0x02

--- a/avr/bootloaders/athena/src/serial.c
+++ b/avr/bootloaders/athena/src/serial.c
@@ -24,6 +24,8 @@
 #error "Unknown MCU. Cannot find the proper serial bootloader."
 #endif
 
+uint8_t serialFlashing;
+
 void serialInit(void)
 {
 	// Double speed mode USART0

--- a/avr/bootloaders/athena/src/serial.h
+++ b/avr/bootloaders/athena/src/serial.h
@@ -152,7 +152,7 @@
 
 /* Serial status flag, it is set to TRUE if flashing from
  * serial is currently active */
-uint8_t serialFlashing;
+extern uint8_t serialFlashing;
 
 /*
  * Function definitions


### PR DESCRIPTION
## Description

Fix misuse of read pointer `REG_S3_RX_RD0 ` & write pointer `REG_S3_TX_WR0` for WIZnet shields: W5100 & W5200.
As a result of this fix, `tftpPoll` function, which processing each new packet, was simplified, and the too-long delay, `TFTP_PACKET_DELAY`, in each iteration of `tftpPoll` function was reduced to 5ms (was 400ms).

Fixes #19
Fixes #18 

other changes:
- max address, `MAX_ADDR`, of code area fixed to match the makefile
- global (extern) variables definition

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
see issue #19 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
