### PR TITLE
Fix optiboot

### DIFF
--- a/avr/bootloaders/athena/src/optiboot/optiboot.c
+++ b/avr/bootloaders/athena/src/optiboot/optiboot.c
@@ -79,7 +79,13 @@ uint8_t processOptiboot(void)
 	else if(ch == STK_SET_DEVICE_EXT)
 	{
 		// SET DEVICE EXT is ignored
+		//   avrdude: stk500_set_extended_parms() function send a different message [length]
+		//   based on the reported bootloader version
+#if(BUILD_MAJOR_VER > 1) || ((BUILD_MAJOR_VER == 1) && (BUILD_MINOR_VER > 10))
+		getNch(5);
+#else
 		getNch(4);
+#endif
 	}
 	else if(ch == STK_LOAD_ADDRESS)
 	{

--- a/avr/bootloaders/athena/src/util.c
+++ b/avr/bootloaders/athena/src/util.c
@@ -15,6 +15,7 @@
 #include "debug.h"
 #include "debug_util.h"
 #include "gpio.h"
+#include "tftp.h"
 #include "util.h"
 
 static uint16_t last_timer_1;
@@ -54,18 +55,12 @@ void resetTick(void)
 
 uint8_t timedOut(void)
 {
-	// Never timeout if there is no code in Flash
-#if(FLASHEND > 0x10000)
-	if(pgm_read_word_far(0x0000) == 0xFFFF)
+	// Never timeout if there is no code in flash,
+	//  but if flashing started- we do want to check for timeout
+	if(!tftpFlashing && pgm_read_word(0x0000) == 0xFFFF)
 	{
 		return (0);
 	}
-#else
-	if(pgm_read_word_near(0x0000) == 0xFFFF)
-	{
-		return (0);
-	}
-#endif
 
 	return (tick > TIMEOUT) ? 1 : 0;
 }


### PR DESCRIPTION
## Description

- Fixes #92-  based on the reported version by the bootloader,  `avrdude` sends a different message length for the `STK_SET_DEVICE_EXT` command
- Fix a minor issue with the timeout logic:
bootloader might hang forever if flashing starts and something "bad" happens to the sender before the first `DATA` packet has been sent (e.g. power loss)



