### PR TITLE
remove image validation based on Arduino "signature"

### DIFF
--- a/avr/bootloaders/athena/src/ethernet/tftp.c
+++ b/avr/bootloaders/athena/src/ethernet/tftp.c
@@ -281,21 +281,6 @@ static uint8_t processPacket(void)
 
 				DBG_TFTP(tracePGMlnTftp(mDebugTftp_PLEN); tracenum(packetLength);)
 
-				if(writeAddr == 0)
-				{
-					// First sector - validate
-					if(!validImage(pageBase))
-					{
-#if defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
-						/* FIXME: Validity checks. Small programms (under 512 bytes?) don't
-						 * have the the JMP sections and that is why app.bin was failing.
-						 * When flashing big binaries is fixed, uncomment the break below.*/
-						returnCode = INVALID_IMAGE;
-						break;
-#endif
-					}
-				}
-
 				// Flash packets
 				uint16_t writeValue;
 				for(offset = 0; offset < packetLength;)


### PR DESCRIPTION
fix #88 

assume we want an actual integrity check for the image- I made an `Integrity check DEMO module` which is **inactive** by default:
branch [feature/image-integrity](https://github.com/hagaigold/athena-bootloader/tree/feature/image-integrity).
diff: https://github.com/hagaigold/athena-bootloader/compare/master...feature/image-integrity

@phillipjohnston , can you give it a look and tell if you want it in the code?